### PR TITLE
Add free cooler note to 10 kg and 20 kg options

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,12 +41,12 @@
     <p>Bestel ijsblokjes en haal ze 10 minuten vóór je vaart op bij Café Hesp.</p>
     <div class="cards">
       <div class="card">
-        <h3>10 kg</h3>
+        <h3>10 kg + gratis koelbox</h3>
         <p>€17,50</p>
         <button class="quick" data-kg="10">Snel bestellen</button>
       </div>
       <div class="card">
-        <h3>20 kg</h3>
+        <h3>20 kg + gratis koelbox</h3>
         <p>€25,00</p>
         <button class="quick" data-kg="20">Snel bestellen</button>
       </div>
@@ -58,8 +58,8 @@
       <h2>Bestellen</h2>
       <label for="product">Product</label>
       <select id="product" name="product">
-        <option value="10">10 kg - €17,50</option>
-        <option value="20">20 kg - €25,00</option>
+        <option value="10">10 kg + gratis koelbox - €17,50</option>
+        <option value="20">20 kg + gratis koelbox - €25,00</option>
       </select>
       <label for="amount">Aantal</label>
       <input type="number" id="amount" name="amount" min="1" value="1">
@@ -136,7 +136,7 @@ function buildMessage(){
     `Datum vaart: ${dateEl.value}`,
     `Starttijd: ${startEl.value}`,
     `Ophaaltijd: ${pickupEl.textContent}`,
-    `Product: ${productEl.value} kg`,
+    `Product: ${productEl.value} kg + gratis koelbox`,
     `Aantal: ${amountEl.value}`,
     `Totaal: ${totalEl.textContent}`,
     'Locatie: Café Hesp (om de hoek bij de steiger)'


### PR DESCRIPTION
## Summary
- Mention "+ gratis koelbox" alongside the 10 kg and 20 kg ice products in cards, dropdown, and order message

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad7b33d074832ca926c9cb41165c38