### PR TITLE
Add mobile logo beside header text

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
   body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;margin:0;background:#f9f9f9;color:#222;line-height:1.5}
   header,footer{background:#fff;padding:1rem;box-shadow:0 1px 3px rgba(0,0,0,.1)}
   header h1{margin:0;font-size:1.5rem;display:flex;align-items:center}
+  .mobile-logo{display:none;height:1.5rem;margin-left:.5rem}
   .badge{background:#eee;padding:.2rem .5rem;border-radius:4px;font-size:.8rem;margin-left:.5rem}
   main{padding:1rem}
   .hero{text-align:center}
@@ -27,6 +28,7 @@
   button:hover{background:#0056b3}
   .total-info{margin-top:1rem}
   @media(max-width:480px){
+    .mobile-logo{display:inline-block}
     .cards{flex-direction:column;align-items:center}
     .card{width:100%;max-width:300px}
   }
@@ -34,7 +36,7 @@
 </head>
 <body>
 <header>
-  <h1>IJskoud Amsterdam <span class="badge">Test-run · Betaal bij afhalen</span></h1>
+  <h1>IJskoud Amsterdam <img src="bootijs_kruizen_iceblue.png" alt="BootIJS logo" class="mobile-logo"> <span class="badge">Test-run · Betaal bij afhalen</span></h1>
 </header>
 <main>
   <section class="hero">


### PR DESCRIPTION
## Summary
- show BootIJS logo next to the "IJskoud Amsterdam" header text on mobile devices
- add responsive CSS for mobile logo display

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad7b763164832c94f9dbe0ba670194