### PR TITLE
Specify button type for quick order buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,12 +51,12 @@
       <div class="card">
         <h3>10 kg + gratis koelbox</h3>
         <p>€17,50</p>
-        <button class="quick" data-kg="10">Snel bestellen</button>
+        <button type="button" class="quick" data-kg="10">Snel bestellen</button>
       </div>
       <div class="card">
         <h3>20 kg + gratis koelbox</h3>
         <p>€25,00</p>
-        <button class="quick" data-kg="20">Snel bestellen</button>
+        <button type="button" class="quick" data-kg="20">Snel bestellen</button>
       </div>
     </div>
     <a class="route-btn" href="https://www.google.com/maps/dir/?api=1&destination=Caf%C3%A9%20Hesp%2C%20Amsteldijk%20130%2C%20Amsterdam" target="_blank" rel="noopener">Route naar Café Hesp</a>


### PR DESCRIPTION
## Summary
- prevent implicit form submission by specifying `type="button"` on quick order buttons

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68adab402a64832cb7d03998c08745c8