### PR TITLE
Handle pickup dates around midnight

### DIFF
--- a/index.html
+++ b/index.html
@@ -129,12 +129,16 @@ function updateInfo(){
   const price = prices[prod] * amt;
   totalEl.textContent = formatter.format(price);
   if(startEl.value){
-    const [h,m] = startEl.value.split(':').map(Number);
     const d = new Date(dateEl.value + 'T' + startEl.value);
     d.setMinutes(d.getMinutes() - 10);
     const ph = String(d.getHours()).padStart(2,'0');
     const pm = String(d.getMinutes()).padStart(2,'0');
-    pickupEl.textContent = `${ph}:${pm}`;
+    const pd = d.toISOString().slice(0,10);
+    if(pd !== dateEl.value){
+      pickupEl.textContent = `${pd} ${ph}:${pm}`;
+    }else{
+      pickupEl.textContent = `${ph}:${pm}`;
+    }
   }else{
     pickupEl.textContent = '--:--';
   }
@@ -238,7 +242,10 @@ document.querySelectorAll('.quick').forEach(btn => {
   btn.addEventListener('click', () => {
     productEl.value = btn.dataset.kg;
     const n = new Date();
+    const today = n.toISOString().slice(0,10);
     n.setMinutes(n.getMinutes() + 45);
+    const newDay = n.toISOString().slice(0,10);
+    if(newDay !== today) dateEl.value = newDay;
     startEl.value = `${String(n.getHours()).padStart(2,'0')}:${String(n.getMinutes()).padStart(2,'0')}`;
     updateInfo();
     validateStart();


### PR DESCRIPTION
## Summary
- show pickup date when subtracting 10 minutes moves pickup before midnight
- ensure quick-order updates date if 45-minute offset crosses into next day

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68adac187274832cb6150390036457bf