### PR TITLE
Ensure amount and date inputs are required

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,10 +71,10 @@
       </select>
       <span class="error" aria-live="polite"></span>
       <label for="amount">Aantal</label>
-      <input type="number" id="amount" name="amount" min="1" value="1">
+      <input type="number" id="amount" name="amount" min="1" value="1" required>
       <span class="error" aria-live="polite"></span>
       <label for="date">Datum vaart</label>
-      <input type="date" id="date" name="date">
+      <input type="date" id="date" name="date" required>
       <span class="error" aria-live="polite"></span>
       <label for="start">Starttijd vaart</label>
       <input type="time" id="start" name="start" required min="00:00">


### PR DESCRIPTION
## Summary
- Require amount and date fields in the order form to leverage browser validation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68adac26ae2c832c9a7aebaab2e61f29