### PR TITLE
Display name requirement message

### DIFF
--- a/index.html
+++ b/index.html
@@ -192,7 +192,7 @@ function validateStart(show=true){
 
 function validateName(show=true){
   if(!nameEl.value.trim()){
-    if(show) setError(nameEl,'Naam is verplicht.');
+    if(show) setError(nameEl,'Vul aub een naam in.');
     return false;
   }
   if(show) setError(nameEl,'');
@@ -211,6 +211,8 @@ function validateForm(show=true){
 
 function updateButtonState(){
   whatsappBtn.disabled = !validateForm(false);
+  // Toon foutmelding wanneer naam ontbreekt
+  validateName();
 }
 
 ['change','input'].forEach(ev=>{


### PR DESCRIPTION
## Summary
- Show explicit 'Vul aub een naam in' error message when name field is empty
- Trigger name validation when button state updates so users see reason for disabled WhatsApp ordering

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68adb3690ca0832c8ad82dc9eab276c3