### PR TITLE
Enable Mollie test payments

### DIFF
--- a/bedankt.html
+++ b/bedankt.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+<meta charset="utf-8">
+<title>Bedankt</title>
+</head>
+<body>
+<h1>Bedankt voor je bestelling!</h1>
+<p>Je betaling is ontvangen. Dit was een testtransactie via Mollie.</p>
+<p><a href="./">Terug naar de site</a></p>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -90,6 +90,7 @@
         <p>Ophaaltijd: <span id="pickup" aria-live="polite">--:--</span></p>
       </div>
       <button type="button" id="whatsapp" disabled>Bestel via WhatsApp</button>
+      <button type="button" id="pay" disabled>Betaal (test) met Mollie</button>
     </form>
   </section>
 </main>
@@ -110,6 +111,7 @@ const totalEl = document.getElementById('total');
 const pickupEl = document.getElementById('pickup');
 const appLink = document.getElementById('app-link');
 const whatsappBtn = document.getElementById('whatsapp');
+const payBtn = document.getElementById('pay');
 const orderForm = document.getElementById('order-form');
 
 appLink.href = `https://wa.me/${WHATSAPP_NUMBER}`;
@@ -218,7 +220,9 @@ function validateForm(show=true){
 }
 
 function updateButtonState(){
-  whatsappBtn.disabled = !validateForm(false);
+  const disabled = !validateForm(false);
+  whatsappBtn.disabled = disabled;
+  payBtn.disabled = disabled;
   // Toon foutmelding wanneer naam ontbreekt
   validateName();
 }
@@ -260,6 +264,30 @@ whatsappBtn.addEventListener('click', () => {
   setToday();
   updateInfo();
   updateButtonState();
+});
+
+payBtn.addEventListener('click', async () => {
+  if(!validateForm()){
+    const firstErr = document.querySelector('.error:not(:empty)');
+    if(firstErr) firstErr.previousElementSibling.focus();
+    return;
+  }
+  const amount = (prices[productEl.value] * parseInt(amountEl.value,10)).toFixed(2);
+  try{
+    const res = await fetch('/.netlify/functions/create-payment', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ amount, description: `IJskoud ${productEl.value}kg` })
+    });
+    const data = await res.json();
+    if(data.checkoutUrl){
+      window.location.href = data.checkoutUrl;
+    }else{
+      alert('Betaling kon niet worden gestart.');
+    }
+  }catch(err){
+    alert('Fout bij starten betaling.');
+  }
 });
 
 document.querySelectorAll('.quick').forEach(btn => {

--- a/netlify/functions/create-payment.js
+++ b/netlify/functions/create-payment.js
@@ -1,6 +1,6 @@
 import mollieClient from '@mollie/api-client';
 
-const { MOLLIE_API_KEY } = process.env;
+const { MOLLIE_API_KEY, URL = 'http://localhost:8888' } = process.env;
 const mollie = mollieClient({ apiKey: MOLLIE_API_KEY });
 
 export async function handler(event) {
@@ -21,7 +21,7 @@ export async function handler(event) {
     const payment = await mollie.payments.create({
       amount: { currency: 'EUR', value: Number(amount).toFixed(2) },
       description: description || 'BOOTIJS bestelling',
-      redirectUrl: 'https://matthijshart.github.io/BOOTIJS/bedankt.html'
+      redirectUrl: `${URL}/bedankt.html`
     });
 
     return {


### PR DESCRIPTION
## Summary
- add front-end button and script to start Mollie test checkout
- use Netlify site URL for redirect after payment
- include simple thank-you page after payment

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@mollie%2fapi-client)*

------
https://chatgpt.com/codex/tasks/task_e_68adbefa5d80832c9adb55209b32fabc