### PR TITLE
Add phone metadata to payment

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,6 +79,9 @@
       <label for="start">Starttijd vaart</label>
       <input type="time" id="start" name="start" required min="00:00">
       <span class="error" aria-live="polite"></span>
+      <label for="phone">Telefoonnummer</label>
+      <input type="tel" id="phone" name="phone" required>
+      <span class="error" aria-live="polite"></span>
       <label for="name">Naam</label>
       <input type="text" id="name" name="name" required>
       <span class="error" aria-live="polite"></span>
@@ -105,6 +108,7 @@ const productEl = document.getElementById('product');
 const amountEl = document.getElementById('amount');
 const dateEl = document.getElementById('date');
 const startEl = document.getElementById('start');
+const phoneEl = document.getElementById('phone');
 const nameEl = document.getElementById('name');
 const noteEl = document.getElementById('note');
 const totalEl = document.getElementById('total');
@@ -200,6 +204,15 @@ function validateStart(show=true){
   return true;
 }
 
+function validatePhone(show=true){
+  if(!phoneEl.value.trim()){
+    if(show) setError(phoneEl,'Vul aub een telefoonnummer in.');
+    return false;
+  }
+  if(show) setError(phoneEl,'');
+  return true;
+}
+
 function validateName(show=true){
   if(!nameEl.value.trim()){
     if(show) setError(nameEl,'Vul aub een naam in.');
@@ -214,6 +227,7 @@ function validateForm(show=true){
     () => validateAmount(show),
     () => validateDate(show),
     () => validateStart(show),
+    () => validatePhone(show),
     () => validateName(show)
   ];
   return validators.every(v => v());
@@ -223,8 +237,9 @@ function updateButtonState(){
   const disabled = !validateForm(false);
   whatsappBtn.disabled = disabled;
   payBtn.disabled = disabled;
-  // Toon foutmelding wanneer naam ontbreekt
+  // Toon foutmelding wanneer naam of telefoonnummer ontbreekt
   validateName();
+  validatePhone();
 }
 
 ['change','input'].forEach(ev=>{
@@ -232,6 +247,7 @@ function updateButtonState(){
   amountEl.addEventListener(ev, () => { updateInfo(); validateAmount(); updateButtonState(); });
   dateEl.addEventListener(ev, () => { updateInfo(); validateDate(); validateStart(); updateButtonState(); });
   startEl.addEventListener(ev, () => { updateInfo(); validateStart(); updateButtonState(); });
+  phoneEl.addEventListener(ev, () => { validatePhone(); updateButtonState(); });
   nameEl.addEventListener(ev, () => { validateName(); updateButtonState(); });
 });
 
@@ -277,7 +293,7 @@ payBtn.addEventListener('click', async () => {
     const res = await fetch('/.netlify/functions/create-payment', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ amount, description: `IJskoud ${productEl.value}kg` })
+      body: JSON.stringify({ amount, description: `IJskoud ${productEl.value}kg`, phone: phoneEl.value })
     });
     const data = await res.json();
     if(data.checkoutUrl){

--- a/netlify/functions/create-payment.js
+++ b/netlify/functions/create-payment.js
@@ -2,6 +2,7 @@ import mollieClient from '@mollie/api-client';
 
 const { MOLLIE_API_KEY, URL = 'http://localhost:8888' } = process.env;
 const mollie = mollieClient({ apiKey: MOLLIE_API_KEY });
+const phoneStore = new Map();
 
 export async function handler(event) {
   try {
@@ -13,7 +14,7 @@ export async function handler(event) {
       return { statusCode: 405, body: 'Method Not Allowed' };
     }
 
-    const { amount, description } = JSON.parse(event.body || '{}');
+    const { amount, description, phone } = JSON.parse(event.body || '{}');
     if (!amount || isNaN(Number(amount))) {
       return { statusCode: 400, body: 'Invalid amount' };
     }
@@ -21,8 +22,13 @@ export async function handler(event) {
     const payment = await mollie.payments.create({
       amount: { currency: 'EUR', value: Number(amount).toFixed(2) },
       description: description || 'BOOTIJS bestelling',
-      redirectUrl: `${URL}/bedankt.html`
+      redirectUrl: `${URL}/bedankt.html`,
+      metadata: { phone }
     });
+
+    if (phone) {
+      phoneStore.set(payment.id, phone);
+    }
 
     return {
       statusCode: 200,


### PR DESCRIPTION
## Summary
- collect customer phone number in checkout form and validation
- include phone number in payment request
- attach phone metadata and store it temporarily in Netlify payment function

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68adc11ddda0832caedf4ce9d5e837a4