### PR TITLE
Add Mollie payment webhook with WhatsApp notification

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,3 +4,6 @@
 
 [functions]
   node_bundler = "esbuild"
+
+[functions."payment-webhook"]
+  external_node_modules = ["twilio"]

--- a/netlify/functions/payment-webhook.js
+++ b/netlify/functions/payment-webhook.js
@@ -1,0 +1,47 @@
+import mollieClient from '@mollie/api-client';
+import twilio from 'twilio';
+
+const {
+  MOLLIE_API_KEY,
+  TWILIO_ACCOUNT_SID,
+  TWILIO_AUTH_TOKEN,
+  TWILIO_WHATSAPP_FROM
+} = process.env;
+
+const mollie = mollieClient({ apiKey: MOLLIE_API_KEY });
+const twilioClient = twilio(TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN);
+
+export async function handler(event) {
+  try {
+    if (event.httpMethod !== 'POST') {
+      return { statusCode: 405, body: 'Method Not Allowed' };
+    }
+
+    const paymentId = new URLSearchParams(event.body || '').get('id');
+    if (!paymentId) {
+      return { statusCode: 400, body: 'Missing payment id' };
+    }
+
+    const payment = await mollie.payments.get(paymentId);
+    if (payment.status !== 'paid') {
+      return { statusCode: 200, body: 'Payment not completed' };
+    }
+
+    const phone = payment.metadata && payment.metadata.phone;
+    if (phone && TWILIO_ACCOUNT_SID && TWILIO_AUTH_TOKEN && TWILIO_WHATSAPP_FROM) {
+      const amount = payment.amount?.value;
+      const description = payment.description;
+      const order = payment.metadata?.orderId ? `\nBestelling: ${payment.metadata.orderId}` : '';
+
+      await twilioClient.messages.create({
+        from: `whatsapp:${TWILIO_WHATSAPP_FROM}`,
+        to: `whatsapp:${phone}`,
+        body: `Betaling ontvangen voor ${description} van €${amount}.${order}`
+      });
+    }
+
+    return { statusCode: 200, body: 'Webhook processed' };
+  } catch (err) {
+    return { statusCode: 500, body: `Error: ${err.message}` };
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "type": "module",
   "dependencies": {
-    "@mollie/api-client": "^4.3.3"
+    "@mollie/api-client": "^4.3.3",
+    "twilio": "^4.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- add payment webhook function to handle Mollie payment status
- send WhatsApp message via Twilio when payment is paid
- configure function in netlify.toml and add Twilio dependency

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68adc120ee64832c99b61e9418697127