### PR TITLE
Enlarge mobile logo to double size

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
   body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;margin:0;background:#f9f9f9;color:#222;line-height:1.5}
   header,footer{background:#fff;padding:1rem;box-shadow:0 1px 3px rgba(0,0,0,.1)}
   header h1{margin:0;font-size:1.5rem;display:flex;align-items:center}
-  .mobile-logo{display:none;height:1.5rem;margin-left:.5rem}
+  .mobile-logo{display:none;height:3rem;margin-left:.5rem}
   .badge{background:#eee;padding:.2rem .5rem;border-radius:4px;font-size:.8rem;margin-left:.5rem}
   main{padding:1rem}
   .hero{text-align:center}


### PR DESCRIPTION
## Summary
- Double the height of the mobile three-cross logo to improve visibility on small screens

## Testing
- `npm test` *(fails: Missing script "test"*)

------
https://chatgpt.com/codex/tasks/task_e_68adc1699440832cb3c9410a1888a028