### PR TITLE
Match quick order button color to cross logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,8 +11,8 @@
 <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>❄️</text></svg>">
 <style>
   :root{
-    --color-primary:#007bff;
-    --color-primary-hover:#0056b3;
+    --color-primary:#00aeef;
+    --color-primary-hover:#008bbf;
   }
   body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;margin:0;background:#f9f9f9;color:#222;line-height:1.5}
   header,footer{background:#fff;padding:1rem;box-shadow:0 1px 3px rgba(0,0,0,.1)}


### PR DESCRIPTION
## Summary
- update quick order button colors to match the light-blue cross logo

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68adc187b258832cbabbef60c70fc039