### PR TITLE
Add phone number field with validation and message inclusion

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,6 +82,9 @@
       <label for="name">Naam</label>
       <input type="text" id="name" name="name" required>
       <span class="error" aria-live="polite"></span>
+      <label for="phone">Telefoonnummer</label>
+      <input type="tel" id="phone" name="phone" required pattern="0[0-9]{9}">
+      <span class="error" aria-live="polite"></span>
       <label for="note">Opmerking (optioneel)</label>
       <textarea id="note" name="note"></textarea>
       <span class="error" aria-live="polite"></span>
@@ -106,6 +109,7 @@ const amountEl = document.getElementById('amount');
 const dateEl = document.getElementById('date');
 const startEl = document.getElementById('start');
 const nameEl = document.getElementById('name');
+const phoneEl = document.getElementById('phone');
 const noteEl = document.getElementById('note');
 const totalEl = document.getElementById('total');
 const pickupEl = document.getElementById('pickup');
@@ -209,12 +213,23 @@ function validateName(show=true){
   return true;
 }
 
+function validatePhone(show=true){
+  const val = phoneEl.value.trim();
+  if(!/^0\d{9}$/.test(val)){
+    if(show) setError(phoneEl,'Vul een geldig telefoonnummer in (10 cijfers).');
+    return false;
+  }
+  if(show) setError(phoneEl,'');
+  return true;
+}
+
 function validateForm(show=true){
   const validators = [
     () => validateAmount(show),
     () => validateDate(show),
     () => validateStart(show),
-    () => validateName(show)
+    () => validateName(show),
+    () => validatePhone(show)
   ];
   return validators.every(v => v());
 }
@@ -226,6 +241,7 @@ function updateButtonState(){
   // Toon foutmeldingen wanneer verplichte velden ontbreken
   validateStart();
   validateName();
+  validatePhone();
 }
 
 ['change','input'].forEach(ev=>{
@@ -234,11 +250,13 @@ function updateButtonState(){
   dateEl.addEventListener(ev, () => { updateInfo(); validateDate(); validateStart(); updateButtonState(); });
   startEl.addEventListener(ev, () => { updateInfo(); validateStart(); updateButtonState(); });
   nameEl.addEventListener(ev, () => { validateName(); updateButtonState(); });
+  phoneEl.addEventListener(ev, () => { validatePhone(); updateButtonState(); });
 });
 
 function buildMessage(){
   const lines = [
     `Naam: ${nameEl.value}`,
+    `Telefoon: ${phoneEl.value}`,
     `Datum vaart: ${dateEl.value}`,
     `Starttijd: ${startEl.value}`,
     `Ophaaltijd: ${pickupEl.textContent}`,
@@ -278,7 +296,7 @@ payBtn.addEventListener('click', async () => {
     const res = await fetch('/.netlify/functions/create-payment', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ amount, description: `IJskoud ${productEl.value}kg` })
+      body: JSON.stringify({ amount, description: `IJskoud ${productEl.value}kg`, phone: phoneEl.value })
     });
     const data = await res.json();
     if(data.checkoutUrl){

--- a/netlify/functions/create-payment.js
+++ b/netlify/functions/create-payment.js
@@ -13,16 +13,21 @@ export async function handler(event) {
       return { statusCode: 405, body: 'Method Not Allowed' };
     }
 
-    const { amount, description } = JSON.parse(event.body || '{}');
+    const { amount, description, phone } = JSON.parse(event.body || '{}');
     if (!amount || isNaN(Number(amount))) {
       return { statusCode: 400, body: 'Invalid amount' };
     }
 
-    const payment = await mollie.payments.create({
+    const paymentData = {
       amount: { currency: 'EUR', value: Number(amount).toFixed(2) },
       description: description || 'BOOTIJS bestelling',
       redirectUrl: `${URL}/bedankt.html`
-    });
+    };
+    if (phone) {
+      paymentData.metadata = { phone };
+    }
+
+    const payment = await mollie.payments.create(paymentData);
 
     return {
       statusCode: 200,


### PR DESCRIPTION
## Summary
- collect customer phone numbers with a new required field and validation
- include phone numbers in WhatsApp messages and payment metadata

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68adc65b2694832ca0e74ac4e910a345