### PR TITLE
feat: verify Mollie webhook signatures

### DIFF
--- a/netlify/functions/payment-webhook.js
+++ b/netlify/functions/payment-webhook.js
@@ -1,11 +1,13 @@
 import mollieClient from '@mollie/api-client';
 import twilio from 'twilio';
+import crypto from 'crypto';
 
 const {
   MOLLIE_API_KEY,
   TWILIO_ACCOUNT_SID,
   TWILIO_AUTH_TOKEN,
-  TWILIO_WHATSAPP_FROM
+  TWILIO_WHATSAPP_FROM,
+  MOLLIE_SIGNING_KEY
 } = process.env;
 
 const mollie = mollieClient({ apiKey: MOLLIE_API_KEY });
@@ -17,7 +19,35 @@ export async function handler(event) {
       return { statusCode: 405, body: 'Method Not Allowed' };
     }
 
-    const paymentId = new URLSearchParams(event.body || '').get('id');
+    const signatureHeader = event.headers['x-mollie-signature'] || event.headers['X-Mollie-Signature'];
+    if (!signatureHeader || !MOLLIE_SIGNING_KEY) {
+      console.warn('Missing signature header or signing key');
+      return { statusCode: 403, body: 'Invalid signature' };
+    }
+
+    const bodyBuffer = event.isBase64Encoded
+      ? Buffer.from(event.body || '', 'base64')
+      : Buffer.from(event.body || '', 'utf8');
+    const bodyString = bodyBuffer.toString('utf8');
+    const expectedSignature = crypto
+      .createHmac('sha256', MOLLIE_SIGNING_KEY)
+      .update(bodyBuffer)
+      .digest('base64');
+
+    const expectedBuf = Buffer.from(expectedSignature);
+    const headerBuf = Buffer.from(signatureHeader);
+    if (
+      expectedBuf.length !== headerBuf.length ||
+      !crypto.timingSafeEqual(expectedBuf, headerBuf)
+    ) {
+      console.warn('Mollie signature verification failed', {
+        expected: expectedSignature,
+        received: signatureHeader
+      });
+      return { statusCode: 403, body: 'Invalid signature' };
+    }
+
+    const paymentId = new URLSearchParams(bodyString).get('id');
     if (!paymentId) {
       return { statusCode: 400, body: 'Missing payment id' };
     }


### PR DESCRIPTION
## Summary
- verify webhook authenticity using Mollie signing key and return 403 on failure
- log invalid signature attempts for easier monitoring

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68addc849fec832c8eab6bbfab8d19dd