### PR TITLE
Show logo on larger screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
   body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;margin:0;background:#f9f9f9;color:#222;line-height:1.5}
   header,footer{background:#fff;padding:1rem;box-shadow:0 1px 3px rgba(0,0,0,.1)}
   header h1{margin:0;font-size:1.5rem;display:flex;align-items:center}
-  .mobile-logo{display:none;height:3rem;margin-left:.5rem}
+  .mobile-logo{display:inline-block;height:3rem;margin-left:.5rem}
   .badge{background:#eee;padding:.2rem .5rem;border-radius:4px;font-size:.8rem;margin-left:.5rem}
   main{padding:1rem}
   .hero{text-align:center}
@@ -34,7 +34,6 @@
   .total-info{margin-top:1rem}
   .error{color:#c00;font-size:.9rem;min-height:1.2em;display:block}
   @media(max-width:480px){
-    .mobile-logo{display:inline-block}
     .cards{flex-direction:column;align-items:center}
     .card{width:100%;max-width:300px}
   }


### PR DESCRIPTION
## Summary
- display BootIJS cross logo on laptop screens by removing mobile-only restriction

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68adde45a9b8832cab7805d2017246ad