### PR TITLE
Require international format phone numbers

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,11 +33,6 @@
   button:hover{background:var(--color-primary-hover)}
   .total-info{margin-top:1rem}
   .error{color:#c00;font-size:.9rem;min-height:1.2em;display:block}
-  .phone-group{display:flex;margin-top:.25rem}
-  .phone-group span{padding:.5rem;border:1px solid #ccc;border-right:none;border-radius:4px 0 0 4px;background:#eee}
-  .phone-group input{width:auto;margin-top:0}
-  #country{max-width:4rem;border-radius:0}
-  #phone{flex:1;border-radius:0 4px 4px 0;margin-left:-1px}
   @media(max-width:480px){
     .cards{flex-direction:column;align-items:center}
     .card{width:100%;max-width:300px}
@@ -86,12 +81,8 @@
       <label for="name">Naam</label>
       <input type="text" id="name" name="name" required>
       <span class="error" aria-live="polite"></span>
-      <label for="country">Telefoonnummer</label>
-      <div id="phone-group" class="phone-group">
-        <span>+</span>
-        <input type="tel" id="country" name="country" required pattern="[0-9]{1,3}" placeholder="31">
-        <input type="tel" id="phone" name="phone" required pattern="[0-9]{9}" placeholder="612345678">
-      </div>
+      <label for="phone">Telefoonnummer</label>
+      <input type="tel" id="phone" name="phone" required pattern="\+[0-9]{10,13}" placeholder="+31612345678">
       <span class="error" aria-live="polite"></span>
       <label for="note">Opmerking (optioneel)</label>
       <textarea id="note" name="note"></textarea>
@@ -117,9 +108,7 @@ const amountEl = document.getElementById('amount');
 const dateEl = document.getElementById('date');
 const startEl = document.getElementById('start');
 const nameEl = document.getElementById('name');
-const countryEl = document.getElementById('country');
 const phoneEl = document.getElementById('phone');
-const phoneGroup = document.getElementById('phone-group');
 const noteEl = document.getElementById('note');
 const totalEl = document.getElementById('total');
 const pickupEl = document.getElementById('pickup');
@@ -224,17 +213,12 @@ function validateName(show=true){
 }
 
 function validatePhone(show=true){
-  const cc = countryEl.value.trim();
   const num = phoneEl.value.trim();
-  if(!/^\d{1,3}$/.test(cc)){
-    if(show) setError(phoneGroup,'Vul een geldige landcode in.');
+  if(!/^\+[0-9]{10,13}$/.test(num)){
+    if(show) setError(phoneEl,'Vul een geldig telefoonnummer in inclusief landcode, bijv. +31612345678.');
     return false;
   }
-  if(!/^\d{9}$/.test(num)){
-    if(show) setError(phoneGroup,'Vul een geldig telefoonnummer in (9 cijfers).');
-    return false;
-  }
-  if(show) setError(phoneGroup,'');
+  if(show) setError(phoneEl,'');
   return true;
 }
 
@@ -265,14 +249,13 @@ function updateButtonState(){
   dateEl.addEventListener(ev, () => { updateInfo(); validateDate(); validateStart(); updateButtonState(); });
   startEl.addEventListener(ev, () => { updateInfo(); validateStart(); updateButtonState(); });
   nameEl.addEventListener(ev, () => { validateName(); updateButtonState(); });
-  countryEl.addEventListener(ev, () => { validatePhone(); updateButtonState(); });
   phoneEl.addEventListener(ev, () => { validatePhone(); updateButtonState(); });
 });
 
 function buildMessage(){
   const lines = [
     `Naam: ${nameEl.value}`,
-    `Telefoon: +${countryEl.value}${phoneEl.value}`,
+    `Telefoon: ${phoneEl.value}`,
     `Datum vaart: ${dateEl.value}`,
     `Starttijd: ${startEl.value}`,
     `Ophaaltijd: ${pickupEl.textContent}`,
@@ -312,7 +295,7 @@ payBtn.addEventListener('click', async () => {
     const res = await fetch('/.netlify/functions/create-payment', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ amount, description: `IJskoud ${productEl.value}kg`, phone: `+${countryEl.value}${phoneEl.value}` })
+      body: JSON.stringify({ amount, description: `IJskoud ${productEl.value}kg`, phone: phoneEl.value })
     });
     const data = await res.json();
     if(data.checkoutUrl){


### PR DESCRIPTION
## Summary
- replace separate country code fields with single phone input requiring `+` and digits
- validate phone number in international format and use it for messages and payment metadata

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68ade0e8e264832cb5760c0832622fb4