### PR TITLE
Add Mollie signing key configuration and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# BOOTIJS
+
+Deze project gebruikt Netlify Functions om Mollie-betalingen te verwerken en WhatsApp-berichten te versturen met Twilio.
+
+## Omgevingsvariabelen
+
+Zorg ervoor dat de volgende variabelen zijn ingesteld in Netlify of in een lokale `.env`:
+
+- `MOLLIE_API_KEY`
+- `MOLLIE_SIGNING_KEY`
+- `TWILIO_ACCOUNT_SID`
+- `TWILIO_AUTH_TOKEN`
+- `TWILIO_WHATSAPP_FROM`
+
+### MOLLIE_SIGNING_KEY verkrijgen
+
+1. Log in op het [Mollie-dashboard](https://www.mollie.com/dashboard).
+2. Ga naar **Developers** ➔ **Webhooks**.
+3. Klik op **Show signing key** en kopieer de sleutel.
+4. Stel deze waarde in als `MOLLIE_SIGNING_KEY` in Netlify.
+
+Gebruik een testbetaling om de webhook te valideren. De `MOLLIE_SIGNING_KEY` wordt gebruikt om de `X-Mollie-Signature` header te verifiëren.
+

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,9 @@
 [build]
   command = ""
   publish = "."
+[build.environment]
+  # Signing key voor Mollie webhook signature verificatie
+  MOLLIE_SIGNING_KEY = ""
 
 [functions]
   node_bundler = "esbuild"


### PR DESCRIPTION
## Summary
- add `MOLLIE_SIGNING_KEY` to Netlify build environment
- document how to obtain signing key from the Mollie dashboard

## Testing
- `node -e "process.env.MOLLIE_SIGNING_KEY='test_key'; import('./netlify/functions/payment-webhook.js').then(async ({handler}) => { const body=''; const sig='invalid'; const res=await handler({httpMethod:'POST', headers:{'x-mollie-signature':sig}, body, isBase64Encoded:false}); console.log(res); });"` *(fails: mollieClient is not a function)*
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68aec8aed968832cb24749a240933bb3