### PR TITLE
Add Netlify env instructions and local .env support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+MOLLIE_API_KEY=your_mollie_api_key

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules/
+
+.env

--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# BOOTIJS
+
+## Netlify configuratie
+
+### MOLLIE_API_KEY instellen
+1. Ga in Netlify naar **Site settings → Build & deploy → Environment**.
+2. Voeg de variabele `MOLLIE_API_KEY` toe met je Mollie API-sleutel.
+3. Deploys mislukken automatisch wanneer deze variabele ontbreekt.
+
+### Lokale ontwikkeling
+1. Kopieer het voorbeeldbestand en vul je sleutel in:
+   ```bash
+   cp .env.example .env
+   # Open .env en vul MOLLIE_API_KEY in
+   ```
+2. Netlify Functions laden automatisch waarden uit `.env` via [dotenv](https://github.com/motdotla/dotenv).
+3. Controleer je setup lokaal met:
+   ```bash
+   MOLLIE_API_KEY=your_key npm run build
+   ```
+
+## Deploy
+Tijdens de Netlify-deploy wordt `npm run build` uitgevoerd; dit script controleert of `MOLLIE_API_KEY` gezet is. Zonder deze variabele stopt de build.
+

--- a/check-env.js
+++ b/check-env.js
@@ -1,0 +1,8 @@
+import 'dotenv/config';
+
+if (!process.env.MOLLIE_API_KEY) {
+  console.error('MOLLIE_API_KEY is not set. Configure it in Netlify or in a local .env file.');
+  process.exit(1);
+}
+
+console.log('MOLLIE_API_KEY is set.');

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-  command = ""
+  command = "npm run build"
   publish = "."
 
 [functions]

--- a/netlify/functions/create-payment.js
+++ b/netlify/functions/create-payment.js
@@ -1,3 +1,4 @@
+import 'dotenv/config';
 import mollieClient from '@mollie/api-client';
 
 const {

--- a/netlify/functions/payment-webhook.js
+++ b/netlify/functions/payment-webhook.js
@@ -1,3 +1,4 @@
+import 'dotenv/config';
 import mollieClient from '@mollie/api-client';
 import twilio from 'twilio';
 import crypto from 'crypto';

--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "type": "module",
   "dependencies": {
     "@mollie/api-client": "^4.3.3",
-    "twilio": "^4.0.0"
+    "twilio": "^4.0.0",
+    "dotenv": "^16.4.1"
+  },
+  "scripts": {
+    "build": "node check-env.js"
   }
 }


### PR DESCRIPTION
## Summary
- document setting `MOLLIE_API_KEY` for Netlify and local development
- load `.env` in Netlify functions and deploy check
- verify `MOLLIE_API_KEY` during Netlify builds

## Testing
- `npm test` *(fails: Missing script: "test")*
- `MOLLIE_API_KEY=test npm run build` *(fails: Cannot find package 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68aec8ad6c88832c97d1d1fd27e1fe85