### PR TITLE
feat: make Twilio optional in payment webhook

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+MOLLIE_API_KEY=your_mollie_api_key
+MOLLIE_SIGNING_KEY=your_mollie_signing_key
+TWILIO_ACCOUNT_SID=your_twilio_account_sid # optional for WhatsApp notifications
+TWILIO_AUTH_TOKEN=your_twilio_auth_token # optional for WhatsApp notifications
+TWILIO_WHATSAPP_FROM=your_twilio_whatsapp_number # optional for WhatsApp notifications

--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# BOOTIJS
+
+Serverless functions for handling Mollie payments and optional WhatsApp notifications via Twilio.
+
+## Environment variables
+
+Create a `.env` file (see `.env.example`) with the following variables:
+
+- `MOLLIE_API_KEY` – Mollie API key.
+- `MOLLIE_SIGNING_KEY` – key used to verify Mollie webhook signatures.
+- `TWILIO_ACCOUNT_SID` – Twilio account SID *(optional, required for WhatsApp notifications)*.
+- `TWILIO_AUTH_TOKEN` – Twilio auth token *(optional)*.
+- `TWILIO_WHATSAPP_FROM` – Twilio WhatsApp-enabled sender number *(optional)*.
+
+If the Twilio variables are not set, the webhook will skip sending WhatsApp messages but still process payments.

--- a/netlify/functions/payment-webhook.js
+++ b/netlify/functions/payment-webhook.js
@@ -59,23 +59,23 @@ export async function handler(event) {
     const phone = payment.metadata && payment.metadata.phone;
     if (phone) {
       if (!TWILIO_ACCOUNT_SID || !TWILIO_AUTH_TOKEN || !TWILIO_WHATSAPP_FROM) {
-        return { statusCode: 500, body: 'Twilio credentials not configured' };
-      }
+        console.warn('Twilio credentials not configured; skipping WhatsApp notification');
+      } else {
+        const twilioClient = twilio(TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN);
 
-      const twilioClient = twilio(TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN);
+        const amount = payment.amount?.value;
+        const description = payment.description;
+        const order = payment.metadata?.orderId ? `\nBestelling: ${payment.metadata.orderId}` : '';
 
-      const amount = payment.amount?.value;
-      const description = payment.description;
-      const order = payment.metadata?.orderId ? `\nBestelling: ${payment.metadata.orderId}` : '';
-
-      try {
-        await twilioClient.messages.create({
-          from: `whatsapp:${TWILIO_WHATSAPP_FROM}`,
-          to: `whatsapp:${phone}`,
-          body: `✅ Betaling ontvangen!\n\nOmschrijving: ${description}\nBedrag: €${amount}${order}\n\n❄️🍦 Tot snel!`
-        });
-      } catch (err) {
-        return { statusCode: 502, body: `Twilio API error: ${err.message}` };
+        try {
+          await twilioClient.messages.create({
+            from: `whatsapp:${TWILIO_WHATSAPP_FROM}`,
+            to: `whatsapp:${phone}`,
+            body: `✅ Betaling ontvangen!\n\nOmschrijving: ${description}\nBedrag: €${amount}${order}\n\n❄️🍦 Tot snel!`
+          });
+        } catch (err) {
+          console.error('Twilio API error:', err.message);
+        }
       }
     }
 

--- a/test/loader.mjs
+++ b/test/loader.mjs
@@ -1,0 +1,9 @@
+export function resolve(specifier, context, defaultResolve) {
+  if (specifier === '@mollie/api-client') {
+    return { url: new URL('./mollie-stub.mjs', import.meta.url).href, shortCircuit: true };
+  }
+  if (specifier === 'twilio') {
+    return { url: new URL('./twilio-stub.mjs', import.meta.url).href, shortCircuit: true };
+  }
+  return defaultResolve(specifier, context, defaultResolve);
+}

--- a/test/mollie-stub.mjs
+++ b/test/mollie-stub.mjs
@@ -1,0 +1,12 @@
+export default function mollieClient() {
+  return {
+    payments: {
+      get: async () => ({
+        status: 'paid',
+        amount: { value: '10.00' },
+        description: 'Test payment',
+        metadata: { phone: '31612345678' }
+      })
+    }
+  };
+}

--- a/test/payment-webhook.test.js
+++ b/test/payment-webhook.test.js
@@ -1,0 +1,34 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import crypto from 'node:crypto';
+import { twilioStubCalled } from './twilio-stub.mjs';
+
+test('webhook processes without Twilio credentials', async () => {
+  process.env.MOLLIE_API_KEY = 'test';
+  process.env.MOLLIE_SIGNING_KEY = 'signing';
+  delete process.env.TWILIO_ACCOUNT_SID;
+  delete process.env.TWILIO_AUTH_TOKEN;
+  delete process.env.TWILIO_WHATSAPP_FROM;
+
+  const { handler } = await import('../netlify/functions/payment-webhook.js');
+
+  const body = 'id=tr_test';
+  const bodyBuffer = Buffer.from(body);
+  const signature = crypto
+    .createHmac('sha256', process.env.MOLLIE_SIGNING_KEY)
+    .update(bodyBuffer)
+    .digest('base64');
+
+  const event = {
+    httpMethod: 'POST',
+    headers: { 'x-mollie-signature': signature },
+    body,
+    isBase64Encoded: false
+  };
+
+  const response = await handler(event);
+
+  assert.equal(response.statusCode, 200);
+  assert.equal(response.body, 'Webhook processed');
+  assert.equal(twilioStubCalled, false);
+});

--- a/test/twilio-stub.mjs
+++ b/test/twilio-stub.mjs
@@ -1,0 +1,11 @@
+export let twilioStubCalled = false;
+
+export default function twilio() {
+  return {
+    messages: {
+      create: async () => {
+        twilioStubCalled = true;
+      }
+    }
+  };
+}


### PR DESCRIPTION
## Summary
- allow webhook to skip Twilio and just log when credentials are missing
- document Twilio environment variables and add .env example
- add tests verifying webhook completes without Twilio keys

## Testing
- `node --test --loader ./test/loader.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68aec8b208f0832c926c6f9975aa9c2f