### PR TITLE
Validate all fields before enabling payment

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,10 +76,10 @@
       <input type="date" id="date" name="date" required>
       <span class="error" aria-live="polite"></span>
       <label for="start">Starttijd vaart</label>
-      <input type="time" id="start" name="start" required min="00:00">
+      <input type="time" id="start" name="start" required min="00:00" placeholder="19:30">
       <span class="error" aria-live="polite"></span>
       <label for="name">Naam</label>
-      <input type="text" id="name" name="name" required>
+      <input type="text" id="name" name="name" required placeholder="Voor- en achternaam">
       <span class="error" aria-live="polite"></span>
       <label for="phone">Telefoonnummer</label>
       <input type="tel" id="phone" name="phone" required pattern="\+[0-9]{10,13}" placeholder="+31612345678">
@@ -245,6 +245,8 @@ function updateButtonState(){
   whatsappBtn.disabled = disabled;
   payBtn.disabled = disabled;
   // Toon foutmeldingen wanneer verplichte velden ontbreken
+  validateAmount();
+  validateDate();
   validateStart();
   validateName();
   validatePhone();


### PR DESCRIPTION
## Summary
- display validation errors for amount and date when buttons remain disabled
- add placeholders for start time and name to guide input

## Testing
- `npm test` *(fails: Missing script)*
- `npm install jsdom@22` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68aec8b33974832c83e5a7cf3f21016d