### PR TITLE
Rename Mollie API env var

### DIFF
--- a/netlify/functions/create-payment.js
+++ b/netlify/functions/create-payment.js
@@ -1,11 +1,11 @@
 import mollieClient from '@mollie/api-client';
 
 const {
-  MOLLIE_API_KEY,
+  MOLLIE_API,
   URL = 'http://localhost:8888',
   WEBHOOK_URL
 } = process.env;
-const mollie = mollieClient({ apiKey: MOLLIE_API_KEY });
+const mollie = mollieClient({ apiKey: MOLLIE_API });
 
 function jsonError(statusCode, message) {
   return {
@@ -17,8 +17,8 @@ function jsonError(statusCode, message) {
 
 export async function handler(event) {
   try {
-    if (!MOLLIE_API_KEY) {
-      return jsonError(500, 'MOLLIE_API_KEY not configured');
+    if (!MOLLIE_API) {
+      return jsonError(500, 'MOLLIE_API not configured');
     }
 
     if (event.httpMethod !== 'POST') {

--- a/netlify/functions/payment-webhook.js
+++ b/netlify/functions/payment-webhook.js
@@ -3,14 +3,14 @@ import twilio from 'twilio';
 import crypto from 'crypto';
 
 const {
-  MOLLIE_API_KEY,
+  MOLLIE_API,
   TWILIO_ACCOUNT_SID,
   TWILIO_AUTH_TOKEN,
   TWILIO_WHATSAPP_FROM,
   MOLLIE_SIGNING_KEY
 } = process.env;
 
-const mollie = mollieClient({ apiKey: MOLLIE_API_KEY });
+const mollie = mollieClient({ apiKey: MOLLIE_API });
 
 export async function handler(event) {
   try {


### PR DESCRIPTION
## Summary
- use `MOLLIE_API` instead of `MOLLIE_API_KEY` and adjust Mollie client instantiation
- update missing-config error message for new env var

## Testing
- `node --check netlify/functions/create-payment.js`
- `node --check netlify/functions/payment-webhook.js`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aed2674480832cb38af42589d87a4a