### PR TITLE
docs: rename mollie api var and add testing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Deze project gebruikt Netlify Functions om Mollie-betalingen te verwerken en Wha
 
 Zorg ervoor dat de volgende variabelen zijn ingesteld in Netlify of in een lokale `.env`:
 
-- `MOLLIE_API_KEY`
+- `MOLLIE_API`
 - `MOLLIE_SIGNING_KEY`
 - `TWILIO_ACCOUNT_SID`
 - `TWILIO_AUTH_TOKEN`
@@ -20,4 +20,10 @@ Zorg ervoor dat de volgende variabelen zijn ingesteld in Netlify of in een lokal
 4. Stel deze waarde in als `MOLLIE_SIGNING_KEY` in Netlify.
 
 Gebruik een testbetaling om de webhook te valideren. De `MOLLIE_SIGNING_KEY` wordt gebruikt om de `X-Mollie-Signature` header te verifiëren.
+
+### API-sleutel testen
+
+1. Zet een test API-sleutel (start met `test_`) in `MOLLIE_API`.
+2. Draai `netlify dev` of deploy op Netlify.
+3. Start een betaling via `/.netlify/functions/create-payment` en check de redirect/QR-code.
 


### PR DESCRIPTION
## Summary
- rename `MOLLIE_API_KEY` references in README to `MOLLIE_API`
- document how to test the Mollie API key with `netlify dev`

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68aed268697c832c83bc8c7703d34163