### PR TITLE
chore: add mollie api env variable

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,6 +4,7 @@
 [build.environment]
   # Signing key voor Mollie webhook signature verificatie
   MOLLIE_SIGNING_KEY = ""
+  MOLLIE_API = ""
 
 [functions]
   node_bundler = "esbuild"


### PR DESCRIPTION
## Summary
- add placeholder MOLLIE_API to Netlify environment config

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aed2691acc832cadc9f00ff0df67b9