### PR TITLE
Use MOLLIE_API env var

### DIFF
--- a/netlify/functions/create-payment.js
+++ b/netlify/functions/create-payment.js
@@ -1,11 +1,11 @@
 import mollieClient from '@mollie/api-client';
 
 const {
-  MOLLIE_API_KEY,
+  MOLLIE_API,
   URL = 'http://localhost:8888',
   WEBHOOK_URL
 } = process.env;
-const mollie = mollieClient({ apiKey: MOLLIE_API_KEY });
+const mollie = mollieClient({ apiKey: MOLLIE_API });
 
 function jsonError(statusCode, message) {
   return {
@@ -17,8 +17,8 @@ function jsonError(statusCode, message) {
 
 export async function handler(event) {
   try {
-    if (!MOLLIE_API_KEY) {
-      return jsonError(500, 'MOLLIE_API_KEY not configured');
+    if (!MOLLIE_API) {
+      return jsonError(500, 'MOLLIE_API not configured');
     }
 
     if (event.httpMethod !== 'POST') {


### PR DESCRIPTION
## Summary
- switch to `MOLLIE_API` environment variable for creating payments
- improve configuration error message

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68aed27b1820832c8c7044a86f02842b