### PR TITLE
refactor: rename Mollie API env var

### DIFF
--- a/netlify/functions/payment-webhook.js
+++ b/netlify/functions/payment-webhook.js
@@ -3,14 +3,14 @@ import twilio from 'twilio';
 import crypto from 'crypto';
 
 const {
-  MOLLIE_API_KEY,
+  MOLLIE_API,
   TWILIO_ACCOUNT_SID,
   TWILIO_AUTH_TOKEN,
   TWILIO_WHATSAPP_FROM,
   MOLLIE_SIGNING_KEY
 } = process.env;
 
-const mollie = mollieClient({ apiKey: MOLLIE_API_KEY });
+const mollie = mollieClient({ apiKey: MOLLIE_API });
 
 export async function handler(event) {
   try {


### PR DESCRIPTION
## Summary
- use `MOLLIE_API` environment variable
- initialize Mollie client with new env var name

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aed27c51f4832ca857ae54d49bc057