### PR TITLE
chore: rename Mollie API env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Deze project gebruikt Netlify Functions om Mollie-betalingen te verwerken en Wha
 
 Zorg ervoor dat de volgende variabelen zijn ingesteld in Netlify of in een lokale `.env`:
 
-- `MOLLIE_API_KEY`
+- `MOLLIE_API`
 - `MOLLIE_SIGNING_KEY`
 - `TWILIO_ACCOUNT_SID`
 - `TWILIO_AUTH_TOKEN`


### PR DESCRIPTION
## Summary
- update README to refer to `MOLLIE_API` instead of `MOLLIE_API_KEY`

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aed27cb10c832c8178acc899cfcb3a