### PR TITLE
Add spinning snowflake loader for WhatsApp orders

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,8 +32,10 @@
   button{background:var(--color-primary);color:#fff;border:none;cursor:pointer}
   button:hover{background:var(--color-primary-hover)}
   .total-info{margin-top:1rem}
-  .error{color:#c00;font-size:.9rem;min-height:1.2em;display:block}
-  @media(max-width:480px){
+    .error{color:#c00;font-size:.9rem;min-height:1.2em;display:block}
+    #whatsapp .loading { margin-left:0.5rem; animation:spin 1s linear infinite; }
+    @keyframes spin { from {transform:rotate(0deg);} to {transform:rotate(360deg);} }
+    @media(max-width:480px){
     .cards{flex-direction:column;align-items:center}
     .card{width:100%;max-width:300px}
   }
@@ -94,7 +96,10 @@
         <p>Totaal: <span id="total" aria-live="polite">€0,00</span></p>
         <p>Ophaaltijd: <span id="pickup" aria-live="polite">--:--</span></p>
       </div>
-        <button type="button" id="whatsapp" disabled>Bestel via WhatsApp</button>
+          <button type="button" id="whatsapp" disabled>
+            <span class="btn-text">Bestel via WhatsApp</span>
+            <span class="loading" hidden>❄️</span>
+          </button>
         <button type="button" id="pay" disabled>Betaal (test) met iDEAL</button>
       <div id="payment-result" style="display:none;text-align:center;margin-top:1rem;">
         <p>Scan de QR-code of <a id="payment-link" target="_blank" rel="noopener">klik hier om te betalen</a>.</p>
@@ -305,7 +310,12 @@ function buildMessage(){
 }
 
 whatsappBtn.addEventListener('click', () => {
+  const loader = whatsappBtn.querySelector('.loading');
+  loader.hidden = false;
+  whatsappBtn.disabled = true;
   if(!validateForm()){
+    loader.hidden = true;
+    whatsappBtn.disabled = false;
     const firstErr = document.querySelector('.error:not(:empty)');
     if(firstErr) firstErr.previousElementSibling.focus();
     return;
@@ -317,6 +327,8 @@ whatsappBtn.addEventListener('click', () => {
   setToday();
   updateInfo();
   updateButtonState();
+  loader.hidden = true;
+  whatsappBtn.disabled = false;
 });
 
 payBtn.addEventListener('click', async () => {


### PR DESCRIPTION
## Summary
- show snowflake loading indicator on WhatsApp order button
- animate snowflake with CSS spin and disable button while sending

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aedd559400832cbf9f5a4fa8216711