### PR TITLE
Remove obsolete 'Bestel 3,50' test button

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,7 +46,6 @@
   <h1>IJskoud Amsterdam <img src="ChatGPT Image 26 aug 2025, 18_33_04.png" alt="BootIJS logo" class="mobile-logo"> <span class="badge">Test-run · Betaal bij afhalen</span></h1>
 </header>
 <main>
-  <button onclick="bestel(3.50, 'BOOTIJS bestelling')">Bestel 3,50</button>
   <pre id="out"></pre>
   <section class="hero">
     <p>Bestel ijsblokjes en haal ze 10 minuten vóór je vaart op bij Café Hesp.</p>


### PR DESCRIPTION
## Summary
- remove unused debug `Bestel 3,50` button from index page

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aedf376024832c80301f0a7bb37e97