### PR TITLE
Add Open Graph metadata for WhatsApp sharing

### DIFF
--- a/bedankt.html
+++ b/bedankt.html
@@ -4,6 +4,11 @@
   <meta charset="utf-8">
   <title>Bedankt – IJskoud Amsterdam</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="Bedankt! Je ijs ligt ijskoud klaar bij Café Hesp.">
+  <meta property="og:title" content="Bedankt – IJskoud Amsterdam">
+  <meta property="og:description" content="Bedankt! Je ijs ligt ijskoud klaar bij Café Hesp.">
+  <meta property="og:image" content="images/logo.png">
+  <meta property="og:image:alt" content="BootIJS logo">
   <style>
     body {
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;


### PR DESCRIPTION
## Summary
- ensure WhatsApp and other social platforms show BootIJS logo by defining og:image
- add descriptive Open Graph tags to the thank-you page

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68aee792acf4832c9b0b8b085d2cec23