### PR TITLE
Ensure sticky order bar shows on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,10 +66,10 @@
     font-size:1.25rem;
     padding:1rem;
     z-index:999;
-    display:none;
+    display:block;
   }
-  @media(max-width:768px){
-    .sticky-order{display:block;}
+  @media(min-width:769px){
+    .sticky-order{display:none;}
   }
 </style>
 </head>


### PR DESCRIPTION
## Summary
- Always display sticky order bar on small screens and hide only on desktop.

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aeedfb67f8832cae4174c044564bde