### PR TITLE
Remove sticky order bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,21 +56,6 @@
     box-shadow:0 2px 6px rgba(0,0,0,0.1);
     font-style:italic;
   }
-  .sticky-order{
-    position:fixed;
-    bottom:0;
-    left:0;
-    right:0;
-    background:var(--color-primary);
-    color:#fff;
-    font-size:1.25rem;
-    padding:1rem;
-    z-index:999;
-    display:block;
-  }
-  @media(min-width:769px){
-    .sticky-order{display:none;}
-  }
 </style>
 </head>
 <body>
@@ -157,7 +142,6 @@
 <footer>
   <p>© <span id="year"></span> IJskoud Amsterdam · <a href="https://www.google.com/maps/dir/?api=1&destination=Caf%C3%A9%20Hesp%2C%20Amsteldijk%20130%2C%20Amsterdam" target="_blank" rel="noopener">Café Hesp</a> · <a id="app-link" href="#">Vragen? App ons.</a></p>
 </footer>
-<button class="sticky-order">Bestel nu ❄️</button>
 <script>
 const WHATSAPP_NUMBER = '31624978211'; // TODO: vervang door jouw nummer (zonder +)
 const prices = { '10': 17.50, '20': 25.00 };
@@ -429,12 +413,6 @@ document.querySelectorAll('.quick').forEach(btn => {
   });
 });
 
-const stickyOrderBtn = document.querySelector('.sticky-order');
-if(stickyOrderBtn){
-  stickyOrderBtn.addEventListener('click', () => {
-    document.getElementById('order-form').scrollIntoView({behavior:'smooth'});
-  });
-}
 
 loadCountryCodes();
 updateInfo();


### PR DESCRIPTION
## Summary
- remove unused sticky "Bestel nu" bar from homepage
- strip related styles and JavaScript

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aeef5c6c54832cb74706b3120a57d6