### PR TITLE
Add social preview metadata with absolute logo URL

### DIFF
--- a/bedankt.html
+++ b/bedankt.html
@@ -4,6 +4,17 @@
   <meta charset="utf-8">
   <title>Bedankt – IJskoud Amsterdam</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="Bedankt! Je ijs ligt ijskoud klaar bij Café Hesp.">
+  <meta property="og:title" content="Bedankt – IJskoud Amsterdam">
+  <meta property="og:description" content="Bedankt! Je ijs ligt ijskoud klaar bij Café Hesp.">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://bootijs.nl/bedankt.html">
+  <meta property="og:image" content="https://bootijs.nl/images/logo.png">
+  <meta property="og:image:alt" content="BootIJS logo">
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="Bedankt – IJskoud Amsterdam">
+  <meta name="twitter:description" content="Bedankt! Je ijs ligt ijskoud klaar bij Café Hesp.">
+  <meta name="twitter:image" content="https://bootijs.nl/images/logo.png">
   <style>
     body {
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;

--- a/index.html
+++ b/index.html
@@ -7,8 +7,14 @@
 <meta name="description" content="Bestel ijsblokjes en haal ze 10 minuten vóór start op bij Café Hesp.">
 <meta property="og:title" content="IJskoud Amsterdam">
 <meta property="og:description" content="Bestel ijsblokjes en haal ze 10 minuten vóór start op bij Café Hesp.">
-<meta property="og:image" content="images/logo.png">
-<meta property="og:image:alt" content="images/logo.png">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://bootijs.nl/">
+<meta property="og:image" content="https://bootijs.nl/images/logo.png">
+<meta property="og:image:alt" content="BootIJS logo">
+<meta name="twitter:card" content="summary">
+<meta name="twitter:title" content="IJskoud Amsterdam">
+<meta name="twitter:description" content="Bestel ijsblokjes en haal ze 10 minuten vóór start op bij Café Hesp.">
+<meta name="twitter:image" content="https://bootijs.nl/images/logo.png">
 <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>❄️</text></svg>">
 <style>
   :root{


### PR DESCRIPTION
## Summary
- include Open Graph and Twitter metadata using absolute logo URLs so social shares show the site logo
- add same metadata on the thank-you page

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68af10b715bc832ca2275201a412476b