### PR TITLE
feat: add auto-scrolling review carousel

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,20 +47,22 @@
     .card{width:100%;max-width:300px}
   }
   .review {
-    display:flex;
-    flex-direction:column;
-    align-items:center;
-    gap:1.5rem;
+    position:relative;
     margin:2rem auto;
     max-width:600px;
     padding:0 1rem;
   }
   .review-card {
+    display:none;
     background:#fff;
     padding:1rem 1.5rem;
     border-radius:8px;
     box-shadow:0 2px 6px rgba(0,0,0,0.1);
     font-style:italic;
+    text-align:center;
+  }
+  .review-card.active {
+    display:block;
   }
 </style>
 </head>
@@ -87,7 +89,7 @@
     <a class="route-btn" href="https://www.google.com/maps/dir/?api=1&destination=Caf%C3%A9%20Hesp%2C%20Amsteldijk%20130%2C%20Amsterdam" target="_blank" rel="noopener">Route naar Café Hesp</a>
   </section>
   <section class="review">
-    <div class="review-card">
+    <div class="review-card active">
       <div class="stars">★★★★★</div>
       <p>“Super makkelijk en ga het zeker volgende keer weer doen voor ijskoude drankjes aan boord.”</p>
       <span class="author">– Lisa</span>
@@ -97,6 +99,12 @@
       <div class="stars">★★★★★</div>
       <p>“Binnen 5 minuten geregeld en onze drankjes bleven de hele tocht ijskoud. Topservice!”</p>
       <span class="author">– Tom</span>
+    </div>
+
+    <div class="review-card">
+      <div class="stars">★★★★★</div>
+      <p>“Geweldig om zo snel gekoeld te zijn; aanrader!”</p>
+      <span class="author">– Sam</span>
     </div>
   </section>
   <section id="order">
@@ -419,6 +427,15 @@ document.querySelectorAll('.quick').forEach(btn => {
   });
 });
 
+
+
+const reviewCards = document.querySelectorAll('.review-card');
+let currentReview = 0;
+setInterval(() => {
+  reviewCards[currentReview].classList.remove('active');
+  currentReview = (currentReview + 1) % reviewCards.length;
+  reviewCards[currentReview].classList.add('active');
+}, 4000);
 
 loadCountryCodes();
 updateInfo();


### PR DESCRIPTION
## Summary
- Convert static reviews into mini carousel with three auto-rotating cards
- Style review cards for single-card display and add active state
- Add JavaScript to cycle through reviews every 4 seconds

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68af1473f138832cbbabc81539f46c2d