### PR TITLE
Smooth review transitions

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,9 +56,15 @@
     margin:2rem auto;
     max-width:600px;
     padding:0 1rem;
+    min-height:160px;
   }
   .review-card {
-    display:none;
+    position:absolute;
+    top:0;
+    left:0;
+    width:100%;
+    opacity:0;
+    transition:opacity 1.5s ease-in-out;
     background:#fff;
     padding:1rem 1.5rem;
     border-radius:8px;
@@ -67,7 +73,8 @@
     text-align:center;
   }
   .review-card.active {
-    display:block;
+    opacity:1;
+    z-index:1;
   }
   .footer-badges {
     display:flex;
@@ -457,7 +464,7 @@ setInterval(() => {
   reviewCards[currentReview].classList.remove('active');
   currentReview = (currentReview + 1) % reviewCards.length;
   reviewCards[currentReview].classList.add('active');
-}, 4000);
+}, 3500);
 
 loadCountryCodes();
 updateInfo();


### PR DESCRIPTION
## Summary
- Add fading review transitions for a smoother, slower change
- Shorten the display time between reviews

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68af1d778d04832ca90bac6a66401546