### PR TITLE
Enable numeric keypad for amount input

### DIFF
--- a/index.html
+++ b/index.html
@@ -134,7 +134,7 @@
       </select>
       <span class="error" aria-live="polite"></span>
       <label for="amount">Aantal</label>
-      <input type="number" id="amount" name="amount" min="1" value="1" required>
+      <input type="number" id="amount" name="amount" min="1" value="1" required inputmode="numeric">
       <span class="error" aria-live="polite"></span>
       <label for="date">Datum vaart</label>
       <input type="date" id="date" name="date" required>


### PR DESCRIPTION
## Summary
- ensure mobile users get a numeric keypad for the amount field by adding `inputmode="numeric"`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68af2164335c832c8efb55eb08583a21