### PR TITLE
Remove outdated Café Hesp footer link

### DIFF
--- a/index.html
+++ b/index.html
@@ -172,7 +172,6 @@
 </main>
 <footer>
 
-  <p>© <span id="year"></span> IJskoud Amsterdam · <a href="https://www.google.com/maps/dir/?api=1&destination=Caf%C3%A9%20Hesp%2C%20Amsteldijk%20130%2C%20Amsterdam" target="_blank" rel="noopener">Café Hesp</a> · <a id="app-link" href="#">Vragen? App ons.</a></p>
   <div class="footer-badges">
     <img src="images/ideal-card.png" alt="iDEAL logo">
     <img src="images/payments-badge.png" alt="Payments by Mollie">


### PR DESCRIPTION
## Summary
- Remove obsolete footer line referencing Café Hesp.

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68af21a97b48832cb270933b269fcbb4