### PR TITLE
Add OG image dimensions for better WhatsApp sharing

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,9 @@
 <meta property="og:url" content="https://bootijs.nl/">
 <meta property="og:image" content="https://bootijs.nl/images/bootijs_kruizen_iceblue.png">
 <meta property="og:image:alt" content="BootIJS logo">
+<meta property="og:image:type" content="image/png">
+<meta property="og:image:width" content="510">
+<meta property="og:image:height" content="340">
 <meta name="twitter:card" content="summary">
 <meta name="twitter:title" content="IJskoud Amsterdam">
 <meta name="twitter:description" content="Bestel ijsblokjes en haal ze 10 minuten vóór start op bij Schollenbrugstraat 10, 1091 EZ Amsterdam (om de hoek bij Café Hesp).">


### PR DESCRIPTION
## Summary
- specify OG image type, width, and height to improve WhatsApp logo preview

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68af2018f760832cadb0848a76926f6c