### PR TITLE
Update pickup location references to Café Bam Boa

### DIFF
--- a/bedankt.html
+++ b/bedankt.html
@@ -4,16 +4,16 @@
   <meta charset="utf-8">
   <title>Bedankt – IJskoud Amsterdam</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="Bedankt! Je ijs ligt ijskoud klaar bij Schollenbrugstraat 10, 1091 EZ Amsterdam (om de hoek bij Café Hesp).">
+  <meta name="description" content="Bedankt! Je ijs ligt ijskoud klaar bij Schollenbrugstraat 10, 1091 EZ Amsterdam, op slechts 2 minuten lopen van de opstaplocatie bij Café Bam Boa.">
   <meta property="og:title" content="Bedankt – IJskoud Amsterdam">
-  <meta property="og:description" content="Bedankt! Je ijs ligt ijskoud klaar bij Schollenbrugstraat 10, 1091 EZ Amsterdam (om de hoek bij Café Hesp).">
+  <meta property="og:description" content="Bedankt! Je ijs ligt ijskoud klaar bij Schollenbrugstraat 10, 1091 EZ Amsterdam, op slechts 2 minuten lopen van de opstaplocatie bij Café Bam Boa.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://bootijs.nl/bedankt.html">
   <meta property="og:image" content="https://bootijs.nl/images/bootijs_kruizen_iceblue.png">
   <meta property="og:image:alt" content="BootIJS logo">
   <meta name="twitter:card" content="summary">
   <meta name="twitter:title" content="Bedankt – IJskoud Amsterdam">
-  <meta name="twitter:description" content="Bedankt! Je ijs ligt ijskoud klaar bij Schollenbrugstraat 10, 1091 EZ Amsterdam (om de hoek bij Café Hesp).">
+  <meta name="twitter:description" content="Bedankt! Je ijs ligt ijskoud klaar bij Schollenbrugstraat 10, 1091 EZ Amsterdam, op slechts 2 minuten lopen van de opstaplocatie bij Café Bam Boa.">
   <meta name="twitter:image" content="https://bootijs.nl/images/bootijs_kruizen_iceblue.png">
 
   <style>
@@ -66,7 +66,7 @@
 <body>
   <div class="emoji">❄️👋</div>
   <h1>Bedankt! Je ijs ligt ijskoud klaar.</h1>
-  <p>We zien je zo bij Schollenbrugstraat 10, 1091 EZ Amsterdam (om de hoek bij Café Hesp). 🚤</p>
+  <p>We zien je zo bij Schollenbrugstraat 10, 1091 EZ Amsterdam, op slechts 2 minuten lopen van de opstaplocatie bij Café Bam Boa. 🚤</p>
   <p>Gebruik deze code bij het afhalen:</p>
   <div class="code" id="order-code">--</div>
   <a href="./">Terug naar de site</a>

--- a/index.html
+++ b/index.html
@@ -4,16 +4,16 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>IJskoud Amsterdam</title>
-<meta name="description" content="Bestel ijsblokjes en haal ze 10 minuten vóór start op bij Schollenbrugstraat 10, 1091 EZ Amsterdam (om de hoek bij Café Hesp).">
+<meta name="description" content="Bestel ijsblokjes en haal ze 10 minuten vóór start op bij Schollenbrugstraat 10, 1091 EZ Amsterdam, op slechts 2 minuten lopen van de opstaplocatie bij Café Bam Boa.">
 <meta property="og:title" content="IJskoud Amsterdam">
-<meta property="og:description" content="Bestel ijsblokjes en haal ze 10 minuten vóór start op bij Schollenbrugstraat 10, 1091 EZ Amsterdam (om de hoek bij Café Hesp).">
+<meta property="og:description" content="Bestel ijsblokjes en haal ze 10 minuten vóór start op bij Schollenbrugstraat 10, 1091 EZ Amsterdam, op slechts 2 minuten lopen van de opstaplocatie bij Café Bam Boa.">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://bootijs.nl/">
 <meta property="og:image" content="https://bootijs.nl/images/bootijs_kruizen_iceblue.png">
 <meta property="og:image:alt" content="BootIJS logo">
 <meta name="twitter:card" content="summary">
 <meta name="twitter:title" content="IJskoud Amsterdam">
-<meta name="twitter:description" content="Bestel ijsblokjes en haal ze 10 minuten vóór start op bij Schollenbrugstraat 10, 1091 EZ Amsterdam (om de hoek bij Café Hesp).">
+<meta name="twitter:description" content="Bestel ijsblokjes en haal ze 10 minuten vóór start op bij Schollenbrugstraat 10, 1091 EZ Amsterdam, op slechts 2 minuten lopen van de opstaplocatie bij Café Bam Boa.">
 <meta name="twitter:image" content="https://bootijs.nl/images/bootijs_kruizen_iceblue.png">
 
 <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>❄️</text></svg>">
@@ -90,7 +90,7 @@
 <main>
   <pre id="out"></pre>
   <section class="hero">
-    <p>Bestel ijsblokjes en haal ze 10 minuten vóór je vaart op bij Schollenbrugstraat 10, 1091 EZ Amsterdam (om de hoek bij Café Hesp).</p>
+    <p>Bestel ijsblokjes en haal ze 10 minuten vóór je vaart op bij Schollenbrugstraat 10, 1091 EZ Amsterdam, op slechts 2 minuten lopen van de opstaplocatie bij Café Bam Boa.</p>
     <div class="cards">
       <div class="card">
         <h3>10 kg + gratis koelbox</h3>
@@ -172,13 +172,13 @@
 </main>
 <footer>
 
-  <p>© <span id="year"></span> IJskoud Amsterdam · <a href="https://www.google.com/maps/dir/?api=1&destination=Caf%C3%A9%20Hesp%2C%20Amsteldijk%20130%2C%20Amsterdam" target="_blank" rel="noopener">Café Hesp</a> · <a id="app-link" href="#">Vragen? App ons.</a></p>
+  <p>© <span id="year"></span> IJskoud Amsterdam · <a href="https://www.google.com/maps/dir/?api=1&destination=Caf%C3%A9%20Bam%20Boa%2C%20Weesperzijde%20135%2C%20Amsterdam" target="_blank" rel="noopener">Café Bam Boa</a> · <a id="app-link" href="#">Vragen? App ons.</a></p>
   <div class="footer-badges">
     <img src="images/ideal-card.png" alt="iDEAL logo">
     <img src="images/payments-badge.png" alt="Payments by Mollie">
   </div>
 
-  <p>© <span id="year"></span> IJskoud Amsterdam · <a href="https://www.google.com/maps/dir/?api=1&destination=Schollenbrugstraat%2010%2C%201091%20EZ%20Amsterdam" target="_blank" rel="noopener">Schollenbrugstraat 10, 1091 EZ Amsterdam (om de hoek bij Café Hesp)</a> · <a id="app-link" href="#">Vragen? App ons.</a></p>
+  <p>© <span id="year"></span> IJskoud Amsterdam · <a href="https://www.google.com/maps/dir/?api=1&destination=Schollenbrugstraat%2010%2C%201091%20EZ%20Amsterdam" target="_blank" rel="noopener">Schollenbrugstraat 10, 1091 EZ Amsterdam, op slechts 2 minuten lopen van de opstaplocatie bij Café Bam Boa</a> · <a id="app-link" href="#">Vragen? App ons.</a></p>
 
 </footer>
 <script>
@@ -372,7 +372,7 @@ function buildMessage(){
     `Product: ${productEl.value} kg + gratis koelbox`,
     `Aantal: ${amountEl.value}`,
     `Totaal: ${totalEl.textContent}`,
-    'Locatie: Schollenbrugstraat 10, 1091 EZ Amsterdam (om de hoek bij Café Hesp)'
+    'Locatie: Schollenbrugstraat 10, 1091 EZ Amsterdam, op slechts 2 minuten lopen van de opstaplocatie bij Café Bam Boa'
   ];
   if(noteEl.value.trim()) lines.push(`Opmerking: ${noteEl.value.trim()}`);
   lines.push('Betaal bij afhalen (contant of Tikkie).');


### PR DESCRIPTION
## Summary
- replace references to Café Hesp with orientation to Café Bam Boa in meta tags, hero, footer links, and WhatsApp message
- adjust footer map link to point to Café Bam Boa and clarify pickup location
- apply same wording updates to bedankt page metadata and confirmation text

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68af228c13ac832ca51ec97c4448ffda