### PR TITLE
Link address to Google Maps

### DIFF
--- a/bedankt.html
+++ b/bedankt.html
@@ -66,7 +66,7 @@
 <body>
   <div class="emoji">❄️👋</div>
   <h1>Bedankt! Je ijs ligt ijskoud klaar.</h1>
-  <p>We zien je zo bij Schollenbrugstraat 10, 1091 EZ Amsterdam (om de hoek bij Café Hesp). 🚤</p>
+  <p>We zien je zo bij <a href="https://maps.google.com/?q=Schollenbrugstraat%2010,%201091%20EZ%20Amsterdam" target="_blank" rel="noopener">Schollenbrugstraat 10, 1091 EZ Amsterdam</a> (om de hoek bij Café Hesp). 🚤</p>
   <p>Gebruik deze code bij het afhalen:</p>
   <div class="code" id="order-code">--</div>
   <a href="./">Terug naar de site</a>

--- a/index.html
+++ b/index.html
@@ -93,7 +93,7 @@
 <main>
   <pre id="out"></pre>
   <section class="hero">
-    <p>Bestel ijsblokjes en haal ze 10 minuten vóór je vaart op bij Schollenbrugstraat 10, 1091 EZ Amsterdam (om de hoek bij Café Hesp).</p>
+    <p>Bestel ijsblokjes en haal ze 10 minuten vóór je vaart op bij <a href="https://maps.google.com/?q=Schollenbrugstraat%2010,%201091%20EZ%20Amsterdam" target="_blank" rel="noopener">Schollenbrugstraat 10, 1091 EZ Amsterdam</a> (om de hoek bij Café Hesp).</p>
     <div class="cards">
       <div class="card">
         <h3>10 kg + gratis koelbox</h3>


### PR DESCRIPTION
## Summary
- make address text on homepage and thank-you page link to Google Maps location.

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68af2477a770832c8fdb8545b02fa5fa