### PR TITLE
Remove route link to Schollenbrugstraat address

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,7 +36,6 @@
   .card{background:#fff;padding:1rem;border-radius:8px;box-shadow:0 1px 3px rgba(0,0,0,.1);width:150px}
   .card h3{margin-top:0}
   .card button{margin-top:.5rem}
-  .route-btn{display:inline-block;margin-top:1rem;color:var(--color-primary)}
   .form-card{background:#fff;padding:1rem;border-radius:8px;box-shadow:0 1px 3px rgba(0,0,0,.1);max-width:400px;margin:0 auto}
   label{display:block;margin-top:.5rem}
   input,select,textarea{width:100%;padding:0.75rem;margin-top:.25rem;border:1px solid #ccc;border-radius:4px;font-size:1rem}
@@ -110,7 +109,6 @@
         <button type="button" class="quick" data-kg="20">Snel bestellen</button>
       </div>
     </div>
-    <a class="route-btn" href="https://www.google.com/maps/dir/?api=1&destination=Schollenbrugstraat%2010%2C%201091%20EZ%20Amsterdam" target="_blank" rel="noopener">Route naar Schollenbrugstraat 10, 1091 EZ Amsterdam</a>
   </section>
   <section class="review">
     <div class="review-card active">


### PR DESCRIPTION
## Summary
- remove route button linking to Schollenbrugstraat 10 from the homepage
- drop unused route button styling

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68af2541b3d8832c9c7afdf2481dc0b0