### PR TITLE
Remove outdated ice pickup tagline

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,9 +4,9 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>IJskoud Amsterdam</title>
-<meta name="description" content="Bestel je ijsblokjes online en haal ze 10 minuten voor vertrek op bij Schollenbrugstraat 10 (1091 EZ Amsterdam, naast Café Hesp). Zo ga je met koele drankjes het water op.">
+<meta name="description" content="Bestel ijsblokjes en haal ze 10 minuten vóór je vaart op bij Schollenbrugstraat 10, 1091 EZ Amsterdam (om de hoek bij Café Hesp).">
 <meta property="og:title" content="IJskoud Amsterdam">
-<meta property="og:description" content="Bestel je ijsblokjes online en haal ze 10 minuten voor vertrek op bij Schollenbrugstraat 10 (1091 EZ Amsterdam, naast Café Hesp). Zo ga je met koele drankjes het water op.">
+<meta property="og:description" content="Bestel ijsblokjes en haal ze 10 minuten vóór je vaart op bij Schollenbrugstraat 10, 1091 EZ Amsterdam (om de hoek bij Café Hesp).">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://bootijs.nl/">
 <meta property="og:image" content="https://bootijs.nl/images/bootijs_kruizen_iceblue.png">
@@ -16,7 +16,7 @@
 <meta property="og:image:height" content="340">
 <meta name="twitter:card" content="summary">
 <meta name="twitter:title" content="IJskoud Amsterdam">
-<meta name="twitter:description" content="Bestel je ijsblokjes online en haal ze 10 minuten voor vertrek op bij Schollenbrugstraat 10 (1091 EZ Amsterdam, naast Café Hesp). Zo ga je met koele drankjes het water op.">
+<meta name="twitter:description" content="Bestel ijsblokjes en haal ze 10 minuten vóór je vaart op bij Schollenbrugstraat 10, 1091 EZ Amsterdam (om de hoek bij Café Hesp).">
 <meta name="twitter:image" content="https://bootijs.nl/images/bootijs_kruizen_iceblue.png">
 
 <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>❄️</text></svg>">
@@ -94,9 +94,6 @@
   <section class="hero">
 
     <p>Bestel ijsblokjes en haal ze 10 minuten vóór je vaart op bij <a href="https://maps.google.com/?q=Schollenbrugstraat%2010,%201091%20EZ%20Amsterdam" target="_blank" rel="noopener">Schollenbrugstraat 10, 1091 EZ Amsterdam</a> (om de hoek bij Café Hesp).</p>
-
-    <p>Bestel je ijsblokjes online en haal ze 10 minuten voor vertrek op bij Schollenbrugstraat 10 (1091 EZ Amsterdam, naast Café Hesp). Zo ga je met koele drankjes het water op.</p>
-
     <div class="cards">
       <div class="card">
         <h3>10 kg + gratis koelbox</h3>


### PR DESCRIPTION
## Summary
- remove outdated online-ordering paragraph
- update metadata descriptions with concise pickup info
- tidy hero section spacing

## Testing
- `npm test` *(fails: Missing script "test" )*

------
https://chatgpt.com/codex/tasks/task_e_68af269adcb4832ca09bc6708a50c5fd