### PR TITLE
Add cooler images to product cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,6 +37,7 @@
   .card{background:#fff;padding:1rem;border-radius:8px;box-shadow:0 1px 3px rgba(0,0,0,.1);width:150px}
   .card h3{margin-top:0}
   .card button{margin-top:.5rem}
+  .coolbox-img{display:block;margin:.5rem auto;width:60px;height:auto}
   .form-card{background:#fff;padding:1rem;border-radius:8px;box-shadow:0 1px 3px rgba(0,0,0,.1);max-width:400px;margin:0 auto}
   label{display:block;margin-top:.5rem}
   input,select,textarea{width:100%;padding:0.75rem;margin-top:.25rem;border:1px solid #ccc;border-radius:4px;font-size:1rem}
@@ -101,11 +102,13 @@
     <div class="cards">
       <div class="card">
         <h3>10 kg + gratis koelbox</h3>
+        <img src="5a17dcfc-b594-4a64-8c1e-c7aa3428856b.webp" alt="Koelbox" class="coolbox-img">
         <p>€17,50</p>
         <button type="button" class="quick" data-kg="10">Snel bestellen</button>
       </div>
       <div class="card">
         <h3>20 kg + gratis koelbox</h3>
+        <img src="5a17dcfc-b594-4a64-8c1e-c7aa3428856b.webp" alt="Koelbox" class="coolbox-img">
         <p>€25,00</p>
         <button type="button" class="quick" data-kg="20">Snel bestellen</button>
       </div>


### PR DESCRIPTION
## Summary
- add `.coolbox-img` style for compact cooler image
- include small cooler image on 10 kg and 20 kg cards

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68b6ac874a18832caf3505ddc693ed8b