### PR TITLE
Add blurred Koelkar image to site header

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,10 +27,56 @@
   }
   .location-link{color:var(--color-primary);}
   body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;margin:0;background:#f9f9f9;color:#222;line-height:1.5}
-  header,footer{background:#fff;padding:1rem;box-shadow:0 1px 3px rgba(0,0,0,.1)}
-  header h1{margin:0;font-size:1.5rem;display:flex;align-items:center}
+  header{
+    position:relative;
+    height:60vh;
+    display:flex;
+    align-items:center;
+    justify-content:center;
+    text-align:center;
+    color:#fff;
+    overflow:hidden;
+  }
+  header::before{
+    content:"";
+    position:absolute;
+    top:0;
+    left:0;
+    width:100%;
+    height:100%;
+    background:url("Koelkar.png") no-repeat center/cover;
+    filter:blur(4px);
+    transform:scale(1.05);
+  }
+  header::after{
+    content:"";
+    position:absolute;
+    top:0;
+    left:0;
+    width:100%;
+    height:100%;
+    background:rgba(0,0,0,0.5);
+  }
+  header h1{
+    margin:0;
+    font-size:3rem;
+    font-weight:bold;
+    display:flex;
+    align-items:center;
+    justify-content:center;
+    gap:.5rem;
+    position:relative;
+    z-index:1;
+  }
+  header p{
+    font-size:1.3rem;
+    margin-top:10px;
+    position:relative;
+    z-index:1;
+  }
   .mobile-logo{display:inline-block;height:6rem;margin-left:.5rem}
   .badge{background:#eee;padding:.2rem .5rem;border-radius:4px;font-size:.8rem;margin-left:.5rem}
+  footer{background:#fff;padding:1rem;box-shadow:0 1px 3px rgba(0,0,0,.1)}
   main{padding:1rem}
   .hero{text-align:center}
   .cards{display:flex;gap:1rem;flex-wrap:wrap;justify-content:center;margin:1rem 0}
@@ -89,7 +135,10 @@
 </head>
 <body>
 <header>
-  <h1>LekkerKoel Amsterdam <img src="images/logo.png" alt="BootIJS logo" class="mobile-logo"> <span class="badge">Test-run</span></h1>
+  <div>
+    <h1>LekkerKoel Amsterdam <img src="images/logo.png" alt="BootIJS logo" class="mobile-logo"> <span class="badge">Test-run</span></h1>
+    <p>Jij regelt de mensen, wij de rest</p>
+  </div>
 </header>
 <main>
   <pre id="out"></pre>


### PR DESCRIPTION
## Summary
- Use Koelkar.png as a hero header background with a blur and dark overlay to keep text legible.
- Center header content and add tagline text "Jij regelt de mensen, wij de rest".

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b6b1ccefc0832c82121d05aac45e9e